### PR TITLE
Fix rand dev-dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.31"
 [dev-dependencies]
 criterion = { version = "0.8", default-features = false }
 fst = "0.4"
-rand = { version = "0.10.0", features = ["small_rng"] }
+rand = { version = "0.8", features = ["small_rng"] }
 roaring = "0.11"
 ucd-trie = { version = "0.1", default-features = false }
 unicode-id = "0.3.6"


### PR DESCRIPTION
## Summary
- change the `rand` dev-dependency from `0.10.0` to `0.8`
- keep the `small_rng` feature used by the benchmark code
- restore successful dependency resolution for `cargo check`

## Testing
- cargo check