### PR TITLE
ci: add security analysis workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,12 +5,12 @@ on:
   pull_request:
     types: [opened, synchronize]
     paths:
-      - '.github/workflows/**'
+      - ".github/workflows/**"
   push:
     branches:
       - main
     paths:
-      - '.github/workflows/**'
+      - ".github/workflows/**"
 
 permissions: {}
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,26 @@
+name: Security Analysis
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - '.github/workflows/**'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
+
+jobs:
+  security:
+    name: Security Analysis
+    runs-on: ubuntu-latest
+    steps:
+      - uses: oxc-project/security-action@fbbd523b1e765ceb174cb819b92c453bb1da265e # v1.0.0

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1
       - uses: oxc-project/setup-rust@23f38cfb0c04af97a055f76acee94d5be71c7c82 # v1.0.16
-      - uses: taiki-e/install-action@5939f3337e40968c39aa70f5ecb1417a92fb25a0 # v2
+      - uses: taiki-e/install-action@5939f3337e40968c39aa70f5ecb1417a92fb25a0 # v2.75.15
         with:
           tool: ucd-generate
       - run: curl -LO https://www.unicode.org/Public/zipped/latest/UCD.zip


### PR DESCRIPTION
## Summary
- add the canonical Security Analysis workflow using `oxc-project/security-action`
- replace legacy zizmor workflow files where present

## Testing
- Not run; workflow-only change.
