### PR TITLE
chore: configure clippy exported api lint

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,1 @@
+avoid-breaking-exported-api = false

--- a/benches/id.rs
+++ b/benches/id.rs
@@ -13,6 +13,8 @@
 // functions' time, then dividing by one million (ms -> ns).
 
 #![allow(
+    dead_code,
+    deprecated,
     clippy::incompatible_msrv, // https://github.com/rust-lang/rust-clippy/issues/12257
     clippy::needless_pass_by_value,
 )]

--- a/tests/trie/mod.rs
+++ b/tests/trie/mod.rs
@@ -4,4 +4,6 @@
 #[rustfmt::skip]
 mod trie;
 
+#[allow(unused_imports)]
+#[cfg(test)]
 pub(crate) use self::trie::*;


### PR DESCRIPTION
Ensures clippy is clean with `avoid-breaking-exported-api = false`.

Validated with `cargo clippy --workspace --all-targets --all-features`.
