### PR TITLE
chore: standardize rustfmt config

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,6 @@
+style_edition = "2024"
+use_small_heuristics = "Max"
+use_field_init_shorthand = true
+reorder_modules = true
+merge_derives = true
+remove_nested_parens = true

--- a/benches/id.rs
+++ b/benches/id.rs
@@ -26,10 +26,10 @@ mod roaring;
 #[path = "../tests/trie/mod.rs"]
 mod trie;
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use rand::SeedableRng;
 use rand::distr::{Bernoulli, Distribution, Uniform};
 use rand::rngs::SmallRng;
-use rand::SeedableRng;
 use std::time::Duration;
 
 fn gen_string(p_nonascii: u32) -> String {
@@ -40,11 +40,7 @@ fn gen_string(p_nonascii: u32) -> String {
 
     let mut string = String::new();
     for _ in 0..500_000 {
-        let distribution = if pick_nonascii.sample(&mut rng) {
-            nonascii
-        } else {
-            ascii
-        };
+        let distribution = if pick_nonascii.sample(&mut rng) { nonascii } else { ascii };
         string.push(distribution.sample(&mut rng));
     }
 

--- a/generate/src/main.rs
+++ b/generate/src/main.rs
@@ -83,10 +83,7 @@ fn main() {
         let mut back = [0u8; CHUNK / 2];
         front.copy_from_slice(&chunk[..CHUNK / 2]);
         back.copy_from_slice(&chunk[CHUNK / 2..]);
-        halfchunkmap
-            .entry(front)
-            .or_insert_with(VecDeque::new)
-            .push_back(back);
+        halfchunkmap.entry(front).or_insert_with(VecDeque::new).push_back(back);
     }
 
     let mut halfdense = Vec::<u8>::new();

--- a/generate/src/parse.rs
+++ b/generate/src/parse.rs
@@ -20,10 +20,7 @@ impl Properties {
 }
 
 pub fn parse_id_properties(ucd_dir: &Path) -> Properties {
-    let mut properties = Properties {
-        id_start: Set::new(),
-        id_continue: Set::new(),
-    };
+    let mut properties = Properties { id_start: Set::new(), id_continue: Set::new() };
 
     let filename = "DerivedCoreProperties.txt";
     let path = ucd_dir.join(filename);

--- a/generate/src/write.rs
+++ b/generate/src/write.rs
@@ -1,6 +1,6 @@
+use crate::CHUNK;
 use crate::output::Output;
 use crate::parse::Properties;
-use crate::CHUNK;
 
 const HEAD: &str = "\
 const T: bool = true;
@@ -21,10 +21,7 @@ pub fn output(
     let mut out = Output::new();
     writeln!(out, "{}", HEAD);
 
-    writeln!(
-        out,
-        "pub(crate) static ASCII_START: Align64<[bool; 128]> = Align64([",
-    );
+    writeln!(out, "pub(crate) static ASCII_START: Align64<[bool; 128]> = Align64([");
     for i in 0u8..4 {
         write!(out, "   ");
         for j in 0..32 {
@@ -37,10 +34,7 @@ pub fn output(
     writeln!(out, "]);");
     writeln!(out);
 
-    writeln!(
-        out,
-        "pub(crate) static ASCII_CONTINUE: Align64<[bool; 128]> = Align64([",
-    );
+    writeln!(out, "pub(crate) static ASCII_CONTINUE: Align64<[bool; 128]> = Align64([");
     for i in 0u8..4 {
         write!(out, "   ");
         for j in 0..32 {
@@ -56,11 +50,7 @@ pub fn output(
     writeln!(out, "pub(crate) const CHUNK: usize = {};", CHUNK);
     writeln!(out);
 
-    writeln!(
-        out,
-        "pub(crate) static TRIE_START: Align8<[u8; {}]> = Align8([",
-        index_start.len(),
-    );
+    writeln!(out, "pub(crate) static TRIE_START: Align8<[u8; {}]> = Align8([", index_start.len());
     for line in index_start.chunks(16) {
         write!(out, "   ");
         for byte in line {
@@ -86,11 +76,7 @@ pub fn output(
     writeln!(out, "]);");
     writeln!(out);
 
-    writeln!(
-        out,
-        "pub(crate) static LEAF: Align64<[u8; {}]> = Align64([",
-        halfdense.len(),
-    );
+    writeln!(out, "pub(crate) static LEAF: Align64<[u8; {}]> = Align64([", halfdense.len());
     for line in halfdense.chunks(16) {
         write!(out, "   ");
         for byte in line {

--- a/tests/compare.rs
+++ b/tests/compare.rs
@@ -18,35 +18,15 @@ fn compare_all_implementations() {
         let thought_to_be_continue = unicode_id_start::is_id_continue(ch);
 
         // unicode-id
-        assert_eq!(
-            thought_to_be_start,
-            unicode_id::UnicodeID::is_id_start(ch),
-            "{ch:?}",
-        );
-        assert_eq!(
-            thought_to_be_continue,
-            unicode_id::UnicodeID::is_id_continue(ch),
-            "{ch:?}",
-        );
+        assert_eq!(thought_to_be_start, unicode_id::UnicodeID::is_id_start(ch), "{ch:?}");
+        assert_eq!(thought_to_be_continue, unicode_id::UnicodeID::is_id_continue(ch), "{ch:?}");
 
         // ucd-trie
-        assert_eq!(
-            thought_to_be_start,
-            trie::ID_START.contains_char(ch),
-            "{ch:?}",
-        );
-        assert_eq!(
-            thought_to_be_continue,
-            trie::ID_CONTINUE.contains_char(ch),
-            "{ch:?}",
-        );
+        assert_eq!(thought_to_be_start, trie::ID_START.contains_char(ch), "{ch:?}");
+        assert_eq!(thought_to_be_continue, trie::ID_CONTINUE.contains_char(ch), "{ch:?}");
 
         // fst
-        assert_eq!(
-            thought_to_be_start,
-            id_start_fst.contains((ch as u32).to_be_bytes()),
-            "{ch:?}",
-        );
+        assert_eq!(thought_to_be_start, id_start_fst.contains((ch as u32).to_be_bytes()), "{ch:?}");
         assert_eq!(
             thought_to_be_continue,
             id_continue_fst.contains((ch as u32).to_be_bytes()),
@@ -54,15 +34,7 @@ fn compare_all_implementations() {
         );
 
         // roaring
-        assert_eq!(
-            thought_to_be_start,
-            id_start_roaring.contains(ch as u32),
-            "{ch:?}",
-        );
-        assert_eq!(
-            thought_to_be_continue,
-            id_continue_roaring.contains(ch as u32),
-            "{ch:?}",
-        );
+        assert_eq!(thought_to_be_start, id_start_roaring.contains(ch as u32), "{ch:?}");
+        assert_eq!(thought_to_be_continue, id_continue_roaring.contains(ch as u32), "{ch:?}");
     }
 }


### PR DESCRIPTION
Standardizes the Rustfmt config filename and options, then applies cargo fmt.
